### PR TITLE
Use the env command instead of the full python path

### DIFF
--- a/src/timeflies.py
+++ b/src/timeflies.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 _version = '0.6'
 


### PR DESCRIPTION
Use the env command so that systems that have python3 in /usr/local/bin or some other place are ok
